### PR TITLE
gitignore: add .vscode to ignored list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode


### PR DESCRIPTION
Adds `.vscode` directory to .gitignore. This directory keeps local,
user-specific configuration for VSCode. Now, developers can customize
their local configuration of VSCode without having to deal with the
`.vscode` directory being displayed by git in the untracked files list.