### PR TITLE
CI: adjust the name of the default branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The GitHub Actions configuration file was modelled after the one used in
scylla-cdc-rust. However, that project uses "main" as the default branch
name, whereas this one uses "master".

This commit adjusts the name of the branch in the events description.