### PR TITLE
s-b: Improve error handling in reads

### DIFF
--- a/src/bin/cql-stress-scylla-bench/operation/read.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/read.rs
@@ -192,7 +192,8 @@ impl ReadOperation {
         stmt: PreparedStatement,
         values: SerializedValues,
     ) -> Result<ControlFlow<()>> {
-        let iter = self.session.execute_iter(stmt, values).await?;
+        let iter =
+            tokio::time::timeout(self.timeout, self.session.execute_iter(stmt, values)).await??;
         let mut iter = iter.into_typed::<(i64, Vec<u8>)>();
 
         // TODO: use driver-side timeouts after they get implemented


### PR DESCRIPTION
Current error handling logic in the read workload does not handle errors returned by `session::execute_iter` properly - they are supposed to be accounted in metrics and ignored, but instead they are returned to the bench runner which fails the whole program. It's not a problem in the older versions of the scylla driver because `execute_iter` was lazy and the first page was fetched in the background, so no errors were returned - but in the newer versions the behavior was changed and now `execute_iter` waits for the first page before returning the iterator and propagates the error from the first fetch, if there was any.

This PR improves and simplifies the read workload error logic so that errors will be handled properly with newer versions of the scylla-rust-driver.