### PR TITLE
Add histogram-related options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -28,21 +28,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "arc-swap"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -91,9 +91,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -112,9 +112,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
@@ -151,9 +151,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -164,6 +164,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
+ "chrono",
  "env_logger",
  "futures",
  "hdrhistogram",
@@ -190,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -200,19 +202,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -220,20 +221,22 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.3.3"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
  "hashbrown",
  "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -241,15 +244,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -260,13 +263,11 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -287,9 +288,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -302,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -312,15 +313,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -329,15 +330,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -346,21 +347,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -376,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -386,13 +387,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -403,9 +404,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
  "base64",
  "byteorder",
@@ -447,9 +448,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbaead50122b06e9a973ac20bc7445074d99ad9a0a0654934876908a9cec82c"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -460,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -477,28 +478,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libm"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -506,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -524,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "minimal-lexical"
@@ -536,34 +531,23 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -574,15 +558,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -598,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -608,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
  "libm",
@@ -649,29 +624,41 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
 ]
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.72"
+name = "openssl-macros"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -682,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -692,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
@@ -705,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -729,28 +716,29 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -778,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -806,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -907,15 +895,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -933,15 +921,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snap"
@@ -951,9 +942,9 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -986,13 +977,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1006,18 +997,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1035,26 +1026,27 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -1065,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1097,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -1110,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1121,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
 ]
@@ -1145,16 +1137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uuid"
@@ -1176,9 +1168,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1273,9 +1265,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1286,30 +1278,30 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0.52"
 async-trait = "0.1.52"
+base64 = "0.13.0"
+chrono = "0.4.9"
 env_logger = "0.9.0"
 futures = "0.3.19"
 hdrhistogram = "7.5.0"

--- a/src/bin/cql-stress-scylla-bench/args.rs
+++ b/src/bin/cql-stress-scylla-bench/args.rs
@@ -63,7 +63,7 @@ pub(crate) struct ScyllaBenchArgs {
     pub iterations: u64,
     // // Any error response that comes with delay greater than errorToTimeoutCutoffTime
     // // to be considered as timeout error and recorded to histogram as such
-    // measureLatency           bool
+    pub measure_latency: bool,
     // hdrLatencyFile           string
     // hdrLatencyUnits          string
     // hdrLatencySigFig         int
@@ -246,6 +246,8 @@ where
         that have a defined number of ops to execute)",
     );
 
+    let measure_latency = flag.bool_var("measure-latency", true, "measure request latency");
+
     let validate_data = flag.bool_var(
         "validate-data",
         false,
@@ -355,6 +357,7 @@ where
             range_count: range_count.get(),
             timeout: timeout.get(),
             iterations: iterations.get(),
+            measure_latency: measure_latency.get(),
             validate_data: validate_data.get(),
         })
     }();

--- a/src/bin/cql-stress-scylla-bench/args.rs
+++ b/src/bin/cql-stress-scylla-bench/args.rs
@@ -64,7 +64,7 @@ pub(crate) struct ScyllaBenchArgs {
     // // Any error response that comes with delay greater than errorToTimeoutCutoffTime
     // // to be considered as timeout error and recorded to histogram as such
     pub measure_latency: bool,
-    // hdrLatencyFile           string
+    pub hdr_latency_file: String,
     pub hdr_latency_resolution: u64,
     pub hdr_latency_sig_fig: u64,
     pub validate_data: bool,
@@ -248,6 +248,11 @@ where
 
     let measure_latency = flag.bool_var("measure-latency", true, "measure request latency");
 
+    let hdr_latency_file = flag.string_var(
+        "hdr-latency-file",
+        "",
+        "log co-fixed and raw latency hdr histograms into a file",
+    );
     let hdr_latency_units = flag.string_var(
         "hdr-latency-units",
         "ns",
@@ -331,7 +336,11 @@ where
             "ns" => 1,
             "us" => 1000,
             "ms" => 1000 * 1000,
-            _ => return Err(anyhow::anyhow!("Unsupported units for hdr-latency-units, supported units are: ns, us,ms"))
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Unsupported units for hdr-latency-units, supported units are: ns, us,ms"
+                ))
+            }
         };
 
         let hdr_latency_sig_fig = hdr_latency_sig_fig.get();
@@ -383,6 +392,7 @@ where
             timeout: timeout.get(),
             iterations: iterations.get(),
             measure_latency: measure_latency.get(),
+            hdr_latency_file: hdr_latency_file.get(),
             hdr_latency_sig_fig,
             hdr_latency_resolution,
             validate_data: validate_data.get(),

--- a/src/bin/cql-stress-scylla-bench/args.rs
+++ b/src/bin/cql-stress-scylla-bench/args.rs
@@ -65,7 +65,7 @@ pub(crate) struct ScyllaBenchArgs {
     // // to be considered as timeout error and recorded to histogram as such
     pub measure_latency: bool,
     // hdrLatencyFile           string
-    // hdrLatencyUnits          string
+    pub hdr_latency_resolution: u64,
     pub hdr_latency_sig_fig: u64,
     pub validate_data: bool,
 }
@@ -248,6 +248,11 @@ where
 
     let measure_latency = flag.bool_var("measure-latency", true, "measure request latency");
 
+    let hdr_latency_units = flag.string_var(
+        "hdr-latency-units",
+        "ns",
+        "ns (nano seconds), us (microseconds), ms (milliseconds)",
+    );
     let hdr_latency_sig_fig = flag.u64_var(
         "hdr-latency-sig",
         3,
@@ -322,6 +327,13 @@ where
         // therefore just subtract with wraparound and treat u64::MAX as infinity
         let max_retries_per_op = max_errors_at_row.get().wrapping_sub(1);
 
+        let hdr_latency_resolution = match hdr_latency_units.get().as_str() {
+            "ns" => 1,
+            "us" => 1000,
+            "ms" => 1000 * 1000,
+            _ => return Err(anyhow::anyhow!("Unsupported units for hdr-latency-units, supported units are: ns, us,ms"))
+        };
+
         let hdr_latency_sig_fig = hdr_latency_sig_fig.get();
         if !(1..=5).contains(&hdr_latency_sig_fig) {
             return Err(anyhow::anyhow!(
@@ -372,6 +384,7 @@ where
             iterations: iterations.get(),
             measure_latency: measure_latency.get(),
             hdr_latency_sig_fig,
+            hdr_latency_resolution,
             validate_data: validate_data.get(),
         })
     }();

--- a/src/bin/cql-stress-scylla-bench/histogram_log_writer.rs
+++ b/src/bin/cql-stress-scylla-bench/histogram_log_writer.rs
@@ -1,0 +1,92 @@
+use std::io::Result;
+use std::marker::Unpin;
+use std::ops::Range;
+use std::time::{Duration, SystemTime};
+
+use chrono::{DateTime, Utc};
+use hdrhistogram::serialization::{Serializer, V2DeflateSerializer};
+use hdrhistogram::Histogram;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+const LOG_FORMAT_VERSION: &str = "1.3";
+
+pub struct HistogramLogOptions<'t> {
+    pub interval_seconds: Range<f64>,
+    pub tag: &'t str,
+}
+
+pub struct HistogramLogWriter<W: AsyncWrite + Unpin> {
+    writer: W,
+}
+
+impl<W: AsyncWrite + Unpin> HistogramLogWriter<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    pub async fn output_log_format_version(&mut self) -> Result<()> {
+        let line = format!("#[Histogram log format version {}]\n", LOG_FORMAT_VERSION);
+        self.writer.write_all(line.as_bytes()).await
+    }
+
+    pub async fn output_comment(&mut self, s: &str) -> Result<()> {
+        let line = format!("#{}\n", s);
+        self.writer.write_all(line.as_bytes()).await
+    }
+
+    pub async fn output_base_time(&mut self, base_time: SystemTime) -> Result<()> {
+        let secs = base_time
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let line = format!("#[Basetime: {} (seconds since epoch)]\n", secs);
+        self.writer.write_all(line.as_bytes()).await
+    }
+
+    pub async fn output_start_time(&mut self, base_time: SystemTime) -> Result<()> {
+        let secs = base_time
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let millis = base_time
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        let rounded_base_time = std::time::UNIX_EPOCH
+            .checked_add(Duration::from_millis(millis as u64))
+            .unwrap();
+        let utc_base_time: DateTime<Utc> = rounded_base_time.into();
+        let line = format!(
+            "#[StartTime: {} (seconds since epoch), {}]\n",
+            secs,
+            utc_base_time.to_rfc3339(),
+        );
+        self.writer.write_all(line.as_bytes()).await
+    }
+
+    pub async fn output_legend(&mut self) -> Result<()> {
+        self.writer.write_all("\"StartTimestamp\",\"Interval_Length\",\"Interval_Max\",\"Interval_Compressed_Histogram\"\n".as_bytes()).await
+    }
+
+    pub async fn output_interval_histogram<'t>(
+        &mut self,
+        histogram: &Histogram<u64>,
+        opts: HistogramLogOptions<'t>,
+    ) -> Result<()> {
+        const MS_TO_NS_RATIO: f64 = 1_000_000.0;
+        let max_value = histogram.max() as f64 / MS_TO_NS_RATIO;
+        let mut raw_encoded_histogram = Vec::new();
+        V2DeflateSerializer::new()
+            .serialize(histogram, &mut raw_encoded_histogram)
+            .unwrap();
+        let line = format!(
+            "Tag={tag},{start_time},{end_time},{max_value},{encoded}\n",
+            tag = opts.tag,
+            start_time = opts.interval_seconds.start,
+            end_time = opts.interval_seconds.end,
+            max_value = max_value,
+            encoded = base64::encode(&raw_encoded_histogram),
+        );
+        self.writer.write_all(line.as_bytes()).await
+    }
+}

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
 
     sb_config.print_configuration();
 
-    let stats_factory = Arc::new(StatsFactory::new(true));
+    let stats_factory = Arc::new(StatsFactory::new(sb_config.measure_latency));
     let sharded_stats = Arc::new(ShardedStats::new(Arc::clone(&stats_factory)));
 
     let run_config = prepare(sb_config.clone(), Arc::clone(&sharded_stats))
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     // from being stopped.
     tokio::task::spawn(stop_on_signal(Arc::clone(&ctrl)));
 
-    let printer = StatsPrinter::new(Some(sb_config.latency_type));
+    let printer = StatsPrinter::new(sb_config.measure_latency.then(|| sb_config.latency_type));
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
     futures::pin_mut!(run_finished);
 

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -29,7 +29,7 @@ use crate::operation::counter_update::CounterUpdateOperationFactory;
 use crate::operation::read::{ReadKind, ReadOperationFactory};
 use crate::operation::scan::ScanOperationFactory;
 use crate::operation::write::WriteOperationFactory;
-use crate::stats::{LatencyType, ShardedStats, StatsFactory, StatsPrinter};
+use crate::stats::{ShardedStats, StatsFactory, StatsPrinter};
 use crate::workload::{
     SequentialConfig, SequentialFactory, TimeseriesReadConfig, TimeseriesReadFactory,
     TimeseriesWriteConfig, TimeseriesWriteFactory, UniformConfig, UniformFactory, WorkloadFactory,
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
     let stats_factory = Arc::new(StatsFactory);
     let sharded_stats = Arc::new(ShardedStats::new(Arc::clone(&stats_factory)));
 
-    let run_config = prepare(sb_config, Arc::clone(&sharded_stats))
+    let run_config = prepare(sb_config.clone(), Arc::clone(&sharded_stats))
         .await
         .context("Failed to prepare the benchmark")?;
 
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     // from being stopped.
     tokio::task::spawn(stop_on_signal(Arc::clone(&ctrl)));
 
-    let printer = StatsPrinter::new(Some(LatencyType::AdjustedForCoordinatorOmission));
+    let printer = StatsPrinter::new(Some(sb_config.latency_type));
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
     futures::pin_mut!(run_finished);
 

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
 
     sb_config.print_configuration();
 
-    let stats_factory = Arc::new(StatsFactory::new(sb_config.measure_latency));
+    let stats_factory = Arc::new(StatsFactory::new(&sb_config));
     let sharded_stats = Arc::new(ShardedStats::new(Arc::clone(&stats_factory)));
 
     let run_config = prepare(sb_config.clone(), Arc::clone(&sharded_stats))

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
 
     sb_config.print_configuration();
 
-    let stats_factory = Arc::new(StatsFactory);
+    let stats_factory = Arc::new(StatsFactory::new(true));
     let sharded_stats = Arc::new(ShardedStats::new(Arc::clone(&stats_factory)));
 
     let run_config = prepare(sb_config.clone(), Arc::clone(&sharded_stats))

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -4,6 +4,7 @@ extern crate async_trait;
 mod args;
 mod distribution;
 mod gocompat;
+mod histogram_log_writer;
 mod operation;
 pub(crate) mod stats;
 mod workload;
@@ -71,7 +72,11 @@ async fn main() -> Result<()> {
     // from being stopped.
     tokio::task::spawn(stop_on_signal(Arc::clone(&ctrl)));
 
-    let printer = StatsPrinter::new(sb_config.measure_latency.then(|| sb_config.latency_type));
+    let mut printer = StatsPrinter::new(
+        sb_config.measure_latency.then_some(sb_config.latency_type),
+        (!sb_config.hdr_latency_file.is_empty()).then_some(sb_config.hdr_latency_file.as_str()),
+    )
+    .await?;
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
     futures::pin_mut!(run_finished);
 
@@ -84,7 +89,7 @@ async fn main() -> Result<()> {
         tokio::select! {
             _ = ticker.tick() => {
                 let partial_stats = sharded_stats.get_combined_and_clear();
-                printer.print_partial(&partial_stats, &mut std::io::stdout())?;
+                printer.print_partial(&partial_stats, &mut std::io::stdout()).await?;
                 combined_stats.combine(&partial_stats);
             }
             result = &mut run_finished => {

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -29,7 +29,7 @@ use crate::operation::counter_update::CounterUpdateOperationFactory;
 use crate::operation::read::{ReadKind, ReadOperationFactory};
 use crate::operation::scan::ScanOperationFactory;
 use crate::operation::write::WriteOperationFactory;
-use crate::stats::{ShardedStats, StatsFactory, StatsPrinter};
+use crate::stats::{LatencyType, ShardedStats, StatsFactory, StatsPrinter};
 use crate::workload::{
     SequentialConfig, SequentialFactory, TimeseriesReadConfig, TimeseriesReadFactory,
     TimeseriesWriteConfig, TimeseriesWriteFactory, UniformConfig, UniformFactory, WorkloadFactory,
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     // from being stopped.
     tokio::task::spawn(stop_on_signal(Arc::clone(&ctrl)));
 
-    let printer = StatsPrinter::new(true);
+    let printer = StatsPrinter::new(Some(LatencyType::AdjustedForCoordinatorOmission));
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
     futures::pin_mut!(run_finished);
 

--- a/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
@@ -81,7 +81,7 @@ impl Operation for CounterUpdateOperation {
         }
 
         let mut stats = self.stats.get_shard_mut();
-        stats.account_op(ctx.scheduled_start_time, &result, cks.len());
+        stats.account_op(ctx, &result, cks.len());
 
         result?;
         Ok(ControlFlow::Continue(()))

--- a/src/bin/cql-stress-scylla-bench/operation/read.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/read.rs
@@ -174,7 +174,7 @@ impl Operation for ReadOperation {
         stats.operations += 1;
         stats.errors += rctx.errors;
         stats.clustering_rows += rctx.rows_read;
-        stats_lock.account_latency(ctx.scheduled_start_time);
+        stats_lock.account_latency(ctx);
 
         result
     }

--- a/src/bin/cql-stress-scylla-bench/operation/scan.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/scan.rs
@@ -108,7 +108,7 @@ impl Operation for ScanOperation {
         stats.operations += 1;
         stats.errors += rctx.errors;
         stats.clustering_rows += rctx.rows_read;
-        stats_lock.account_latency(ctx.scheduled_start_time);
+        stats_lock.account_latency(ctx);
 
         result
     }

--- a/src/bin/cql-stress-scylla-bench/operation/write.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/write.rs
@@ -104,7 +104,7 @@ impl Operation for WriteOperation {
         }
 
         let mut stats = self.stats.get_shard_mut();
-        stats.account_op(ctx.scheduled_start_time, &result, cks.len());
+        stats.account_op(ctx, &result, cks.len());
 
         result?;
         Ok(ControlFlow::Continue(()))

--- a/src/bin/cql-stress-scylla-bench/stats.rs
+++ b/src/bin/cql-stress-scylla-bench/stats.rs
@@ -1,8 +1,11 @@
 use std::io::Write;
-use std::time::Duration;
+use std::ops::Range;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use hdrhistogram::Histogram;
+use tokio::fs::File;
 use tokio::time::Instant;
 
 use cql_stress::configuration::OperationContext;
@@ -10,6 +13,7 @@ use cql_stress::sharded_stats;
 
 use crate::args::ScyllaBenchArgs;
 use crate::gocompat::strconv::format_duration;
+use crate::histogram_log_writer::{HistogramLogOptions, HistogramLogWriter};
 
 pub type ShardedStats = sharded_stats::ShardedStats<StatsFactory>;
 
@@ -132,18 +136,34 @@ pub enum LatencyType {
     AdjustedForCoordinatorOmission,
 }
 
+type HistogramWriter = HistogramLogWriter<File>;
+
 // TODO: Should we have two impls, one with latency and another without?
 pub struct StatsPrinter {
     start_time: Instant,
+    previous_time: Instant,
     latency_type: Option<LatencyType>,
+    histogram_writer: Option<HistogramWriter>,
 }
 
 impl StatsPrinter {
-    pub fn new(latency_type: Option<LatencyType>) -> Self {
-        Self {
-            start_time: Instant::now(),
+    pub async fn new(
+        latency_type: Option<LatencyType>,
+        latency_file_name: Option<&str>,
+    ) -> Result<Self> {
+        let histogram_writer = if let Some(latency_file_name) = latency_file_name {
+            Some(init_hdr_log_writer(latency_file_name).await?)
+        } else {
+            None
+        };
+
+        let now = Instant::now();
+        Ok(Self {
+            start_time: now,
+            previous_time: now,
             latency_type,
-        }
+            histogram_writer,
+        })
     }
 
     pub fn print_header(&self, out: &mut impl Write) -> Result<()> {
@@ -174,8 +194,9 @@ impl StatsPrinter {
         Ok(())
     }
 
-    pub fn print_partial(&self, stats: &Stats, out: &mut impl Write) -> Result<()> {
-        let time = Instant::now() - self.start_time;
+    pub async fn print_partial(&mut self, stats: &Stats, out: &mut impl Write) -> Result<()> {
+        let now = Instant::now();
+        let time = now - self.start_time;
 
         if let Some(typ) = self.latency_type {
             let histogram = stats.get_histogram(typ).unwrap();
@@ -215,6 +236,18 @@ impl StatsPrinter {
                 stats.errors,
             )?;
         }
+
+        if let (Some(latencies), Some(writer)) = (&stats.latencies, &mut self.histogram_writer) {
+            let prev_time = self.previous_time - self.start_time;
+            write_to_latencies_file(
+                writer,
+                latencies,
+                prev_time.as_secs_f64()..time.as_secs_f64(),
+            )
+            .await?;
+        }
+
+        self.previous_time = now;
 
         Ok(())
     }
@@ -273,4 +306,55 @@ impl StatsPrinter {
 
         Ok(())
     }
+}
+
+async fn init_hdr_log_writer(file_name: &str) -> Result<HistogramWriter> {
+    let dir_path = Path::new(file_name)
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("could not get parent dir of the histogram file path"))?;
+    let abs_dir_path = dir_path
+        .canonicalize()
+        .with_context(|| "Failed to canonicalize the hdr latency file directory")?;
+    tokio::fs::create_dir_all(abs_dir_path)
+        .await
+        .with_context(|| "Failed to recursively create all directories for the hdr latency file")?;
+
+    let file = File::create(file_name).await?;
+    let mut log_writer = HistogramLogWriter::new(file);
+
+    log_writer.output_log_format_version().await?;
+    log_writer
+        .output_comment("Logging op latencies for scylla-bench")
+        .await?;
+
+    let base_time = SystemTime::now();
+    log_writer.output_base_time(base_time).await?;
+    log_writer.output_start_time(base_time).await?;
+    log_writer.output_legend().await?;
+
+    Ok(log_writer)
+}
+
+async fn write_to_latencies_file(
+    writer: &mut HistogramWriter,
+    latencies: &LatencyHistograms,
+    interval_seconds: Range<f64>,
+) -> Result<()> {
+    let opts_co_fixed = HistogramLogOptions {
+        interval_seconds: interval_seconds.clone(),
+        tag: "co-fixed",
+    };
+    writer
+        .output_interval_histogram(&latencies.co_fixed, opts_co_fixed)
+        .await?;
+
+    let opts_raw = HistogramLogOptions {
+        interval_seconds,
+        tag: "raw",
+    };
+    writer
+        .output_interval_histogram(&latencies.raw, opts_raw)
+        .await?;
+
+    Ok(())
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -58,6 +58,13 @@ pub struct OperationContext {
     ///
     /// If rate limiting is disabled, this will always be equal to `now`.
     pub scheduled_start_time: Instant,
+
+    /// The time when the operation actually started executing.
+    ///
+    /// Unless rate limiting is enabled and the run does not keep
+    /// with configured rate, this will be either equal or close
+    /// to `scheduled_start_time`.
+    pub actual_start_time: Instant,
 }
 
 /// Creates operations which can later be used by workers during the stress.

--- a/src/run.rs
+++ b/src/run.rs
@@ -97,10 +97,12 @@ impl WorkerContext {
                 } else {
                     Instant::now()
                 };
+                let actual_start_time = Instant::now();
 
                 let ctx = OperationContext {
                     operation_id: op_id,
                     scheduled_start_time,
+                    actual_start_time,
                 };
 
                 match operation.execute(&ctx).await {


### PR DESCRIPTION
This PR add support for the following scylla-bench options related to latency histograms:

- `-latency-type` - determines which type of latency should be printed to the standard output (raw or coordinated-omission fixed),
- `-measure-latency` - controls whether latency should be measured at all,
- `-hdr-latency-sig` - controls the precision of the latency histograms (significant figures),
- `-hdr-latency-units` - determines the units used to record the latency,
- `-hdr-latency-file` - name of the file to which latency information should be saved, in the HistogramLogWriter format. Results can be viewed using e.g. the following page: https://hdrhistogram.github.io/HdrHistogramJSDemo/logparser.html
