### PR TITLE
s-b: improvements to logging

### DIFF
--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use env_logger::Env;
 use futures::future;
 use openssl::ssl::{SslContext, SslContextBuilder, SslFiletype, SslMethod, SslVerifyMode};
 use scylla::{transport::Compression, Session, SessionBuilder};
@@ -37,7 +38,7 @@ use crate::workload::{
 // TODO: Return exit code
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
 
     let sb_config = match args::parse_scylla_bench_args(std::env::args(), true) {
         Some(sb_config) => sb_config,

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -40,6 +40,13 @@ use crate::workload::{
 async fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
 
+    #[cfg(debug_assertions)]
+    {
+        tracing::warn!(
+            "The tool was NOT compiled in release mode, expect poor performance or switch to release mode!"
+        );
+    }
+
     let sb_config = match args::parse_scylla_bench_args(std::env::args(), true) {
         Some(sb_config) => sb_config,
         None => return Err(anyhow::anyhow!("Failed to parse the CLI arguments")),


### PR DESCRIPTION
This PR does two things:

- Changes the default verbosity level from "error" to "warn",
- Adds a warning about running in debug mode (so that users don't accidentally benchmark with a debug version).