### PR TITLE
treewide: appease clippy

### DIFF
--- a/src/bin/cql-stress-scylla-bench/gocompat/strconv.rs
+++ b/src/bin/cql-stress-scylla-bench/gocompat/strconv.rs
@@ -163,7 +163,7 @@ pub fn parse_duration(mut s: &str) -> Result<Duration> {
 
         let unit_multiplicand = UNIT_MULTIPLICANDS
             .iter()
-            .find_map(|(uname, mult)| (&unit == uname).then(|| mult))
+            .find_map(|(uname, mult)| (&unit == uname).then_some(mult))
             .ok_or_else(|| anyhow::anyhow!("Invalid duration unit: {}", unit))?;
 
         // Converting floats to ints when the float is too big to fit is UB,

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -132,8 +132,8 @@ async fn prepare(args: Arc<ScyllaBenchArgs>, stats: Arc<ShardedStats>) -> Result
     create_schema(&session, &args).await?;
     let operation_factory = create_operation_factory(session, stats, Arc::clone(&args)).await?;
 
-    let max_duration = (args.test_duration > Duration::ZERO).then(|| args.test_duration);
-    let rate_limit_per_second = (args.maximum_rate > 0).then(|| args.maximum_rate as f64);
+    let max_duration = (args.test_duration > Duration::ZERO).then_some(args.test_duration);
+    let rate_limit_per_second = (args.maximum_rate > 0).then_some(args.maximum_rate as f64);
 
     Ok(Configuration {
         max_duration,

--- a/src/run.rs
+++ b/src/run.rs
@@ -79,7 +79,7 @@ impl WorkerContext {
     // the stress operation, it will return `None`.
     fn issue_operation_id(&self) -> Option<u64> {
         let id = self.operation_counter.fetch_add(1, Ordering::Relaxed);
-        (id < INVALID_OP_ID_THRESHOLD).then(|| id)
+        (id < INVALID_OP_ID_THRESHOLD).then_some(id)
     }
 
     // Repeatedly runs the `operation` until it is asked to stop


### PR DESCRIPTION
The `bool::then_some` function got stabilized, and clippy started complaining about the usage of `bool::then` with lambdas that immediately return a value. This commit switches uses of `then` to `then_some` where applicable.