### PR TITLE
run: get rid of a per-operation allocation 

### DIFF
--- a/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use scylla::{prepared_statement::PreparedStatement, Session};
 use tracing::error;
 
-use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
 
 use crate::args::ScyllaBenchArgs;
 use crate::stats::ShardedStats;
@@ -60,8 +60,8 @@ impl OperationFactory for CounterUpdateOperationFactory {
     }
 }
 
-#[async_trait]
-impl Operation for CounterUpdateOperation {
+make_runnable!(CounterUpdateOperation);
+impl CounterUpdateOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         // Counter updates always use one key
         let (pk, cks) = match self.workload.generate_keys(1) {

--- a/src/bin/cql-stress-scylla-bench/operation/read.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/read.rs
@@ -7,7 +7,7 @@ use scylla::cql_to_rust::FromRow;
 use scylla::frame::value::{Counter, SerializedValues};
 use scylla::{prepared_statement::PreparedStatement, Session};
 
-use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
 
 use crate::args::{OrderBy, ScyllaBenchArgs};
 use crate::operation::ReadContext;
@@ -144,8 +144,8 @@ impl OperationFactory for ReadOperationFactory {
     }
 }
 
-#[async_trait]
-impl Operation for ReadOperation {
+make_runnable!(ReadOperation);
+impl ReadOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         let mut rctx = ReadContext::default();
 

--- a/src/bin/cql-stress-scylla-bench/operation/scan.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/scan.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use futures::TryStreamExt;
 use scylla::{prepared_statement::PreparedStatement, Session};
 
-use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
 
 use crate::args::ScyllaBenchArgs;
 use crate::operation::ReadContext;
@@ -76,8 +76,8 @@ impl OperationFactory for ScanOperationFactory {
     }
 }
 
-#[async_trait]
-impl Operation for ScanOperation {
+make_runnable!(ScanOperation);
+impl ScanOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         let mut rctx = ReadContext::default();
 

--- a/src/bin/cql-stress-scylla-bench/operation/write.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/write.rs
@@ -11,7 +11,7 @@ use scylla::{
 };
 use tracing::error;
 
-use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
 
 use crate::args::ScyllaBenchArgs;
 use crate::distribution::{Distribution, RngGen};
@@ -80,8 +80,8 @@ impl OperationFactory for WriteOperationFactory {
     }
 }
 
-#[async_trait]
-impl Operation for WriteOperation {
+make_runnable!(WriteOperation);
+impl WriteOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         let (pk, cks) = match self.workload.generate_keys(self.rows_per_op as usize) {
             Some((pk, cks)) => (pk, cks),

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,9 +1,10 @@
-use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use tokio::time::Instant;
+
+use crate::run::WorkerSession;
 
 /// Defines the configuration of a benchmark.
 pub struct Configuration {
@@ -76,10 +77,20 @@ pub trait OperationFactory: Send + Sync {
     fn create(&self) -> Box<dyn Operation>;
 }
 
-/// Represents an operation which is repeatedly performed during the stress.
+/// Represents an operation which runs its own operation loop.
+/// Implementing this interface instead of Operation leads to more efficient
+/// code because Rust, for now, forces us to Box futures returned
+/// from Operation::execute. This trait only incurs one allocation
+/// per running worker.
 #[async_trait]
 pub trait Operation: Send + Sync {
-    /// Executes the operation, given information in the OperationContext.
+    /// Classes that implement this trait should have the following, non-trait
+    /// method defined:
+    ///
+    /// async fn execute(&mut self, ctx: OperationContext) -> Result<ControlFlow<()>>;
+    ///
+    /// and they should use make_runnable!(TraitName) macro to generate
+    /// the implementation of the run() method.
     ///
     /// The operation should behave deterministically, i.e. the same action
     /// should be performed when given exactly the same OperationContext.
@@ -89,5 +100,31 @@ pub trait Operation: Send + Sync {
     /// Returns ControlFlow::Break if it should finish work, for example
     /// if the operation ID has exceeded the configured operation count.
     /// In other cases, it returns ControlFlow::Continue.
-    async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>>;
+    async fn run(&mut self, session: WorkerSession) -> Result<()>;
 }
+
+/// Implements Operation for a type which implements an execute method.
+/// Although we could put execute() into the Operation trait, doing what we
+/// are doing here has better performance because asynchronous traits require
+/// putting returned futures in a Box due to current language limitations.
+/// Boxing the futures imply an allocation per operation and those allocations
+/// can be clearly visible on the flamegraphs.
+#[macro_export]
+macro_rules! make_runnable {
+    ($op:ty) => {
+        #[async_trait]
+        impl $crate::configuration::Operation for $op {
+            async fn run(&mut self, mut session: $crate::run::WorkerSession) -> anyhow::Result<()> {
+                while let Some(ctx) = session.start_operation().await {
+                    let result = self.execute(&ctx).await;
+                    if let std::ops::ControlFlow::Break(_) = session.end_operation(result)? {
+                        return Ok(());
+                    }
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+pub use make_runnable;


### PR DESCRIPTION
Currently, Rust does not support async in traits natively and usually
the "async-trait" crate is used to make async methods work. The main
limitation of async-trait is that it requires boxing the future returned
from the async function - so, an allocation.

The `Operation::execute` method is async, so it incurs an allocation for
each operation executed in the benchmark. While the driver itself
performs multiple allocations when handling a single request, for some
reason the allocation related to boxing the future was prominent in
flamegraphs of CPU-bound workloads (it took about 10% of the time).

This commit refactors the Operation so that it is responsible for
running its own `execute` loop in `Operation::run`. In order to make
migration to the new pattern easy, a macro `make_runnable!` is
introduced which generates an implementation of `run` based on the
existing `execute` method. Meanwhile, `execute` is demoted to a
non-trait async method, which Rust supports without any boxing.

This isn't a perfect abstraction because we can't force `run`
implementations to use `make_runnable!`, but the performance gains are
worth it. I couldn't find a way how to make the abstraction more tight;
I tried introducing a generic method which takes an async callback, but
it's very hard (if possible at all) to spell out the types and lifetimes
properly when the async callback takes non-static arguments and borrows
them in the returned future.