### PR TITLE
Reworked to use a more intuitive procedural macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rand_pcg",
+ "runnable_macro",
  "scylla",
  "sha2",
  "thread_local",
@@ -769,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -859,6 +860,16 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "runnable_macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rustversion"
@@ -1019,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+runnable_macro = { path = "runnable_macro" }
 anyhow = "1.0.52"
 async-trait = "0.1.52"
 base64 = "0.13.0"

--- a/runnable_macro/.gitignore
+++ b/runnable_macro/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/runnable_macro/Cargo.toml
+++ b/runnable_macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "runnable_macro"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.21"
+syn = { version = "1.0.103", features = ["full"] }
+proc-macro2 = "1.0.47"
+proc-macro-crate = "1.2.1"

--- a/runnable_macro/src/lib.rs
+++ b/runnable_macro/src/lib.rs
@@ -1,0 +1,38 @@
+use proc_macro::TokenStream;
+use quote::quote_spanned;
+use syn::{parse_macro_input, spanned::Spanned, Item};
+
+/// Implements Operation for a type which implements an execute method.
+/// Although we could put execute() into the Operation trait, doing what we
+/// are doing here has better performance because asynchronous traits require
+/// putting returned futures in a Box due to current language limitations.
+/// Boxing the futures imply an allocation per operation and those allocations
+/// can be clearly visible on the flamegraphs.
+#[proc_macro_derive(Operation)]
+pub fn runnable(input: TokenStream) -> TokenStream {
+    let input_clone = input.clone();
+    let item = parse_macro_input!(input_clone as Item);
+    let runnable_ty = match &item {
+        Item::Struct(s) => &s.ident,
+        Item::Enum(e) => &e.ident,
+        _ => panic!("Nonsupported place for [runnable] macro. Put it above struct/enum definition."),
+    };
+
+    let run_method = quote_spanned!(item.span()=>
+        #[async_trait::async_trait]
+        impl cql_stress::configuration::Operation for #runnable_ty {
+            async fn run(&mut self, mut session: cql_stress::run::WorkerSession) -> anyhow::Result<()> {
+                while let Some(ctx) = session.start().await {
+                    let result = self.execute(&ctx).await;
+                    if let std::ops::ControlFlow::Break(_) = session.end(result)? {
+                        return Ok(());
+                    }
+                }
+                Ok(())
+            }
+        }
+    );
+    // input.extend(TokenStream::from(run_method));
+    // input
+    TokenStream::from(run_method)
+}

--- a/src/bin/cql-stress-scylla-bench/main.rs
+++ b/src/bin/cql-stress-scylla-bench/main.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate async_trait;
 
 mod args;

--- a/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/counter_update.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use scylla::{prepared_statement::PreparedStatement, Session};
 use tracing::error;
 
-use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
 
 use crate::args::ScyllaBenchArgs;
 use crate::stats::ShardedStats;
@@ -17,7 +17,7 @@ pub(crate) struct CounterUpdateOperationFactory {
     statement: PreparedStatement,
     workload_factory: Box<dyn WorkloadFactory>,
 }
-
+#[derive(Operation)]
 struct CounterUpdateOperation {
     session: Arc<Session>,
     stats: Arc<ShardedStats>,
@@ -60,7 +60,6 @@ impl OperationFactory for CounterUpdateOperationFactory {
     }
 }
 
-make_runnable!(CounterUpdateOperation);
 impl CounterUpdateOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         // Counter updates always use one key

--- a/src/bin/cql-stress-scylla-bench/operation/read.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/read.rs
@@ -7,7 +7,7 @@ use scylla::cql_to_rust::FromRow;
 use scylla::frame::value::{Counter, SerializedValues};
 use scylla::{prepared_statement::PreparedStatement, Session};
 
-use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
 
 use crate::args::{OrderBy, ScyllaBenchArgs};
 use crate::operation::ReadContext;
@@ -30,6 +30,7 @@ pub(crate) struct ReadOperationFactory {
     args: Arc<ScyllaBenchArgs>,
 }
 
+#[derive(Operation)]
 struct ReadOperation {
     session: Arc<Session>,
     stats: Arc<ShardedStats>,
@@ -144,7 +145,6 @@ impl OperationFactory for ReadOperationFactory {
     }
 }
 
-make_runnable!(ReadOperation);
 impl ReadOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         let mut rctx = ReadContext::default();

--- a/src/bin/cql-stress-scylla-bench/operation/scan.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/scan.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use futures::TryStreamExt;
 use scylla::{prepared_statement::PreparedStatement, Session};
 
-use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
 
 use crate::args::ScyllaBenchArgs;
 use crate::operation::ReadContext;
@@ -25,6 +25,7 @@ pub(crate) struct ScanOperationFactory {
     shared_state: Arc<SharedState>,
 }
 
+#[derive(Operation)]
 struct ScanOperation {
     session: Arc<Session>,
     stats: Arc<ShardedStats>,
@@ -76,7 +77,6 @@ impl OperationFactory for ScanOperationFactory {
     }
 }
 
-make_runnable!(ScanOperation);
 impl ScanOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         let mut rctx = ReadContext::default();

--- a/src/bin/cql-stress-scylla-bench/operation/write.rs
+++ b/src/bin/cql-stress-scylla-bench/operation/write.rs
@@ -11,7 +11,7 @@ use scylla::{
 };
 use tracing::error;
 
-use cql_stress::configuration::{make_runnable, Operation, OperationContext, OperationFactory};
+use cql_stress::configuration::{Operation, OperationContext, OperationFactory};
 
 use crate::args::ScyllaBenchArgs;
 use crate::distribution::{Distribution, RngGen};
@@ -26,6 +26,7 @@ pub(crate) struct WriteOperationFactory {
     args: Arc<ScyllaBenchArgs>,
 }
 
+#[derive(Operation)]
 struct WriteOperation {
     session: Arc<Session>,
     stats: Arc<ShardedStats>,
@@ -80,7 +81,6 @@ impl OperationFactory for WriteOperationFactory {
     }
 }
 
-make_runnable!(WriteOperation);
 impl WriteOperation {
     async fn execute(&mut self, ctx: &OperationContext) -> Result<ControlFlow<()>> {
         let (pk, cks) = match self.workload.generate_keys(self.rows_per_op as usize) {


### PR DESCRIPTION
This makes usage more idiomatic - Rustaceans are used to putting such attribute macros above some structs.