### PR TITLE
treewide: fix clippy's complaints

### DIFF
--- a/src/bin/cql-stress-scylla-bench/gocompat/strconv.rs
+++ b/src/bin/cql-stress-scylla-bench/gocompat/strconv.rs
@@ -388,7 +388,7 @@ mod tests {
         ];
 
         let it_32 = tests_32.iter().map(|(s, i)| (s, *i as u64, 32));
-        let it_64 = tests_64.iter().map(|(s, i)| (s, *i as u64, 64));
+        let it_64 = tests_64.iter().map(|(s, i)| (s, *i, 64));
 
         let mut succeeded = true;
         for (s, expected, bits) in it_32.chain(it_64) {
@@ -470,7 +470,7 @@ mod tests {
         ];
 
         let it_32 = tests_32.iter().map(|(s, i)| (s, *i as i64, 32));
-        let it_64 = tests_64.iter().map(|(s, i)| (s, *i as i64, 64));
+        let it_64 = tests_64.iter().map(|(s, i)| (s, *i, 64));
 
         let mut succeeded = true;
         for (s, expected, bits) in it_32.chain(it_64) {

--- a/src/bin/cql-stress-scylla-bench/workload/sequential.rs
+++ b/src/bin/cql-stress-scylla-bench/workload/sequential.rs
@@ -107,10 +107,7 @@ impl Workload for Sequential {
 
         let pk = (self.current_pk % self.config.pks) as i64 + self.config.partition_offset;
         let ck_end = std::cmp::min(self.current_ck + ck_count as u64, self.config.cks_per_pk);
-        let cks = (self.current_ck..ck_end)
-            .into_iter()
-            .map(|x| x as i64)
-            .collect();
+        let cks = (self.current_ck..ck_end).map(|x| x as i64).collect();
         self.current_ck = ck_end;
 
         Some((pk, cks))

--- a/src/bin/cql-stress-scylla-bench/workload/timeseries_write.rs
+++ b/src/bin/cql-stress-scylla-bench/workload/timeseries_write.rs
@@ -71,7 +71,7 @@ impl Workload for TimeseriesWrite {
         let pk_generation = ck_position / self.config.cks_per_pk;
 
         let pk = (pk_position << 32) | pk_generation;
-        let ck = -((self.config.start_nanos + self.period_nanos * ck_position as u64) as i64);
+        let ck = -((self.config.start_nanos + self.period_nanos * ck_position) as i64);
 
         Some((pk as i64, vec![ck]))
     }


### PR DESCRIPTION
With the new clippy version comes new lints. This commit fixes the newest complaints so that the CI passes again.