### PR TITLE
fix(read): fix selecting only configured columns

### DIFF
--- a/src/bin/cql-stress-cassandra-stress/operation/read.rs
+++ b/src/bin/cql-stress-cassandra-stress/operation/read.rs
@@ -94,7 +94,17 @@ impl<V: RowValidator> GenericReadOperationFactory<V> {
         session: Arc<Session>,
         stressed_table_name: &'static str,
     ) -> Result<Self> {
-        let statement_str = format!("SELECT * FROM {} WHERE KEY=?", stressed_table_name);
+        let column_list = settings
+            .column
+            .columns
+            .iter()
+            .map(|col| format!("\"{}\"", col))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let statement_str = format!(
+            "SELECT key, {} FROM {} WHERE KEY=?",
+            column_list, stressed_table_name
+        );
         let mut statement = session
             .prepare(statement_str)
             .await


### PR DESCRIPTION
It was reading with `select *` and causing problems when test added columns (validation errors). Cassandra-stress ignores added columns.

fix by querying specific (configured) columns only. Columns must be quoted as otherwise are lowercased and query fails.

closes: https://github.com/scylladb/cql-stress/issues/138