### PR TITLE
Fix for Unused global variable

### DIFF
--- a/tools/util/cassandra_stress.py
+++ b/tools/util/cassandra_stress.py
@@ -155,6 +155,3 @@ class CassandraStress(CSCliRunner):
 class CqlStressCassandraStress(CSCliRunner):
     def __init__(self):
         super().__init__(stress_cmd=["cql-stress-cassandra-stress"])
-
-
-if __name__ == "__main__":


### PR DESCRIPTION
To fix the problem, simply remove the unused variable assignment from the `if __name__ == "__main__":` block. Since `cassandra_stress` is assigned but never read or used, removing this line eliminates the unused global variable as per CodeQL's warning. No further changes or additions are necessary, as there is no functional usage to replace. The only edit required is to delete line 161.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._