### PR TITLE
Fix for 'import *' may pollute namespace

### DIFF
--- a/tools/test_with_scylla.py
+++ b/tools/test_with_scylla.py
@@ -4,7 +4,7 @@ import argparse
 import os
 import subprocess
 
-from util.scylla_docker import *
+from util.scylla_docker import scylla_docker
 
 
 def main():


### PR DESCRIPTION
To fix the problem, we should replace `from util.scylla_docker import *` with explicit imports of only those names that are actually used in this file. Looking at the code, the only symbol from `util.scylla_docker` that is referenced is `scylla_docker` (used on line 26). Thus, we should change line 7 to read `from util.scylla_docker import scylla_docker`. No additional imports or changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._