### PR TITLE
[DO NOT MERGE] custom load balancing policy for strong consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rand = "0.8"
 rand_distr = "0.4"
 rand_pcg = "0.3"
 regex = "1.9.1"
+reqwest = "0.11"
 scylla = { version = "1.2.0", features = ["openssl-010"] }
 sha2 = "0.10"
 strum = "0.25.0"
@@ -66,7 +67,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 rust-strictmath = "0.1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8", optional = true }
-uuid = { version = "1.0", optional = true }
+uuid = "1.0"
 
 [build-dependencies]
 reqwest = { version = "0.11", features = ["json", "blocking"] }
@@ -77,7 +78,7 @@ git2 = "0.20"
 
 [features]
 default = ["user-profile"]
-user-profile = ["dep:serde", "dep:serde_yaml", "dep:uuid"]
+user-profile = ["dep:serde", "dep:serde_yaml"]
 
 [dev-dependencies]
 ntest = "0.9"

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -30,16 +30,19 @@ use operation::{
     CounterReadOperationFactory, CounterWriteOperationFactory, MixedOperationFactory,
     WriteOperationFactory,
 };
+use scylla::client::PoolSize;
 use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::policies::load_balancing::LoadBalancingPolicy;
 use stats::{ShardedStats, StatsFactory, StatsPrinter};
 
-use std::{env, sync::Arc};
+use std::{env, sync::Arc, time::Duration};
 use tracing_subscriber::EnvFilter;
 
 use settings::{CassandraStressParsingResult, CassandraStressSettings};
+
+const SHARD_AWARE_POOL_WARMUP: Duration = Duration::from_secs(2);
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -211,6 +214,8 @@ async fn prepare_run(
         .await
         .context("Failed to initialize raft leader routing")?;
 
+    wait_for_per_shard_pool_warmup(&settings.mode.pool_size).await;
+
     let duration = settings.command_params.common.duration;
 
     let (concurrency, throttle) = match settings.rate.threads_info {
@@ -232,6 +237,16 @@ async fn prepare_run(
         // TODO: adjust when -errors option is supported
         max_retries_per_op: 9,
     })
+}
+
+async fn wait_for_per_shard_pool_warmup(pool_size: &PoolSize) {
+    if matches!(pool_size, PoolSize::PerShard(_)) {
+        println!(
+            "Waiting {:?} for shard-aware pools to warm up...",
+            SHARD_AWARE_POOL_WARMUP
+        );
+        tokio::time::sleep(SHARD_AWARE_POOL_WARMUP).await;
+    }
 }
 
 async fn create_operation_factory(

--- a/src/bin/cql-stress-cassandra-stress/main.rs
+++ b/src/bin/cql-stress-cassandra-stress/main.rs
@@ -4,6 +4,7 @@ extern crate async_trait;
 mod hdr_logger;
 mod java_generate;
 mod operation;
+mod raft_leader_policy;
 mod settings;
 mod stats;
 
@@ -32,6 +33,7 @@ use operation::{
 use scylla::client::execution_profile::ExecutionProfile;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
+use scylla::policies::load_balancing::LoadBalancingPolicy;
 use stats::{ShardedStats, StatsFactory, StatsPrinter};
 
 use std::{env, sync::Arc};
@@ -164,8 +166,25 @@ async fn prepare_run(
         builder = builder.tls_context(Some(ssl_ctx));
     }
 
+    // Determine the target table for raft leader routing
+    let target_table = match settings.command {
+        Command::CounterWrite | Command::CounterRead => "counter1",
+        _ => "standard1",
+    };
+    let target_keyspace = settings.schema.keyspace.clone();
+
+    // Create the RaftLeaderPolicy wrapping the default policy.
+    // The policy is created with an empty mapping; it will be populated
+    // after the session is built and the schema is created.
+    let default_policy = settings.node.load_balancing_policy();
+    let raft_policy = Arc::new(raft_leader_policy::RaftLeaderPolicy::new(
+        target_keyspace,
+        target_table.to_string(),
+        default_policy,
+    ));
+
     let default_exec_profile = ExecutionProfile::builder()
-        .load_balancing_policy(settings.node.load_balancing_policy())
+        .load_balancing_policy(Arc::clone(&raft_policy) as Arc<dyn LoadBalancingPolicy>)
         .build();
     builder = builder.default_execution_profile_handle(default_exec_profile.into_handle());
 
@@ -183,6 +202,14 @@ async fn prepare_run(
         .create_schema(&session)
         .await
         .context("Failed to create schema")?;
+
+    // Initialize the raft leader policy by querying system.tablets
+    // and the ScyllaDB REST API to build the token -> leader mapping.
+    let api_node = raft_leader_policy::extract_host(&settings.node.nodes[0]);
+    raft_policy
+        .initialize(&session, api_node, 10000)
+        .await
+        .context("Failed to initialize raft leader routing")?;
 
     let duration = settings.command_params.common.duration;
 

--- a/src/bin/cql-stress-cassandra-stress/raft_leader_policy.rs
+++ b/src/bin/cql-stress-cassandra-stress/raft_leader_policy.rs
@@ -24,9 +24,9 @@ use uuid::Uuid;
 pub struct RaftLeaderPolicy {
     target_keyspace: String,
     target_table: String,
-    /// Mapping from last_token -> leader host_id.
+    /// Mapping from last_token -> (leader host_id, shard).
     /// Populated after session creation via `initialize()`.
-    token_to_leader: OnceLock<BTreeMap<i64, Uuid>>,
+    token_to_leader: OnceLock<BTreeMap<i64, (Uuid, Shard)>>,
     /// Fallback policy for non-target-table queries or when not yet initialized.
     default_policy: Arc<dyn LoadBalancingPolicy>,
 }
@@ -66,14 +66,14 @@ impl RaftLeaderPolicy {
             get_table_id(session, &self.target_keyspace, &self.target_table).await?;
         println!("  Table ID: {}", table_id);
 
-        // Step 2: Get token -> raft_group_id mapping from system.tablets
+        // Step 2: Get token -> (raft_group_id, replicas) mapping from system.tablets
         let tablet_info = get_tablet_info(session, table_id).await?;
         println!("  Found {} tablets", tablet_info.len());
 
         // Step 3: For each unique raft_group_id, get the leader host_id via REST API
         let http_client = reqwest::Client::new();
         let unique_groups: std::collections::HashSet<Uuid> =
-            tablet_info.iter().map(|(_, group_id)| *group_id).collect();
+            tablet_info.iter().map(|t| t.raft_group_id).collect();
         println!(
             "  Querying raft leaders for {} groups...",
             unique_groups.len()
@@ -93,11 +93,27 @@ impl RaftLeaderPolicy {
             group_to_leader.insert(*group_id, leader_host_id);
         }
 
-        // Build the final token -> leader host_id mapping
+        // Build the final token -> (leader host_id, shard) mapping.
+        // For each tablet, find the replica on the leader host to get the shard.
         let mut token_to_leader = BTreeMap::new();
-        for (last_token, group_id) in &tablet_info {
-            if let Some(&leader) = group_to_leader.get(group_id) {
-                token_to_leader.insert(*last_token, leader);
+        for tablet in &tablet_info {
+            if let Some(&leader_host_id) = group_to_leader.get(&tablet.raft_group_id) {
+                let shard = tablet
+                    .replicas
+                    .iter()
+                    .find(|(host_id, _)| *host_id == leader_host_id)
+                    .map(|(_, shard)| *shard as Shard)
+                    .with_context(|| {
+                        format!(
+                            "Leader {} not found in replicas for tablet with last_token {}",
+                            leader_host_id, tablet.last_token
+                        )
+                    })?;
+                println!(
+                    "    Token {} -> Host {} Shard {}",
+                    tablet.last_token, leader_host_id, shard
+                );
+                token_to_leader.insert(tablet.last_token, (leader_host_id, shard));
             }
         }
 
@@ -113,13 +129,13 @@ impl RaftLeaderPolicy {
         Ok(())
     }
 
-    /// Find the leader host_id for a given token.
+    /// Find the leader host_id and shard for a given token.
     ///
     /// Uses the BTreeMap to find the tablet whose range contains the token.
     /// The tablet ranges are defined by `last_token` boundaries:
     /// a token T belongs to the tablet with the smallest `last_token >= T`.
     /// If T is beyond the largest `last_token`, it wraps around to the first tablet.
-    fn find_leader_host_id(&self, token_value: i64) -> Option<Uuid> {
+    fn find_leader(&self, token_value: i64) -> Option<(Uuid, Shard)> {
         let map = self.token_to_leader.get()?;
         if map.is_empty() {
             return None;
@@ -127,7 +143,7 @@ impl RaftLeaderPolicy {
         // Find the first tablet whose last_token >= the given token
         map.range(token_value..)
             .next()
-            .map(|(_, &uuid)| uuid)
+            .map(|(_, target)| *target)
             // Wrap around: if token > max last_token, use the first tablet
             .or_else(|| map.values().next().copied())
     }
@@ -142,16 +158,17 @@ impl RaftLeaderPolicy {
         }
     }
 
-    /// Find a node in the cluster by its host_id.
+    /// Find a node in the cluster by its host_id, paired with a specific shard.
     fn find_node_by_host_id<'a>(
         host_id: Uuid,
+        shard: Shard,
         cluster: &'a ClusterState,
     ) -> Option<(NodeRef<'a>, Option<Shard>)> {
         cluster
             .get_nodes_info()
             .iter()
             .find(|node| node.host_id == host_id)
-            .map(|node| (node, None))
+            .map(|node| (node, Some(shard)))
     }
 }
 
@@ -161,11 +178,11 @@ impl LoadBalancingPolicy for RaftLeaderPolicy {
         request: &'a RoutingInfo,
         cluster: &'a ClusterState,
     ) -> Option<(NodeRef<'a>, Option<Shard>)> {
-        // For the target table, try to route to the raft leader
+        // For the target table, try to route to the raft leader + shard
         if self.is_target_table(request) {
             if let Some(token) = request.token {
-                if let Some(leader_id) = self.find_leader_host_id(token.value()) {
-                    if let Some(result) = Self::find_node_by_host_id(leader_id, cluster) {
+                if let Some((leader_id, shard)) = self.find_leader(token.value()) {
+                    if let Some(result) = Self::find_node_by_host_id(leader_id, shard, cluster) {
                         return Some(result);
                     }
                 }
@@ -213,12 +230,20 @@ async fn get_table_id(session: &Session, keyspace: &str, table: &str) -> Result<
     Ok(table_id)
 }
 
-/// Query system.tablets to get (last_token, raft_group_id) pairs for a table.
-async fn get_tablet_info(session: &Session, table_id: Uuid) -> Result<Vec<(i64, Uuid)>> {
+/// Information about a single tablet from system.tablets.
+struct TabletInfo {
+    last_token: i64,
+    raft_group_id: Uuid,
+    /// Replicas as (host_id, shard) pairs.
+    replicas: Vec<(Uuid, i32)>,
+}
+
+/// Query system.tablets to get tablet info including replicas for a table.
+async fn get_tablet_info(session: &Session, table_id: Uuid) -> Result<Vec<TabletInfo>> {
     // Format the UUID directly in the query since system virtual tables
     // may not support bind markers well.
     let query = format!(
-        "SELECT last_token, raft_group_id FROM system.tablets WHERE table_id = {}",
+        "SELECT last_token, raft_group_id, replicas FROM system.tablets WHERE table_id = {}",
         table_id
     );
 
@@ -232,10 +257,14 @@ async fn get_tablet_info(session: &Session, table_id: Uuid) -> Result<Vec<(i64, 
         .context("Expected rows result from system.tablets")?;
 
     let mut tablet_info = Vec::new();
-    for row in rows.rows::<(i64, Uuid)>()? {
-        let (last_token, raft_group_id) =
+    for row in rows.rows::<(i64, Uuid, Vec<(Uuid, i32)>)>()? {
+        let (last_token, raft_group_id, replicas) =
             row.context("Failed to deserialize tablet row")?;
-        tablet_info.push((last_token, raft_group_id));
+        tablet_info.push(TabletInfo {
+            last_token,
+            raft_group_id,
+            replicas,
+        });
     }
 
     Ok(tablet_info)
@@ -332,25 +361,25 @@ mod tests {
         let uuid_c = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
 
         let mut map = BTreeMap::new();
-        map.insert(-3000, uuid_a); // tablet A: ...-3000
-        map.insert(0, uuid_b); // tablet B: -2999...0
-        map.insert(3000, uuid_c); // tablet C: 1...3000
+        map.insert(-3000, (uuid_a, 0u32)); // tablet A: ...-3000, shard 0
+        map.insert(0, (uuid_b, 1u32)); // tablet B: -2999...0, shard 1
+        map.insert(3000, (uuid_c, 2u32)); // tablet C: 1...3000, shard 2
 
         policy.token_to_leader.set(map).unwrap();
 
         // Token -5000 -> tablet A (first range)
-        assert_eq!(policy.find_leader_host_id(-5000), Some(uuid_a));
+        assert_eq!(policy.find_leader(-5000), Some((uuid_a, 0)));
         // Token -3000 -> tablet A (boundary)
-        assert_eq!(policy.find_leader_host_id(-3000), Some(uuid_a));
+        assert_eq!(policy.find_leader(-3000), Some((uuid_a, 0)));
         // Token -2999 -> tablet B
-        assert_eq!(policy.find_leader_host_id(-2999), Some(uuid_b));
+        assert_eq!(policy.find_leader(-2999), Some((uuid_b, 1)));
         // Token 0 -> tablet B (boundary)
-        assert_eq!(policy.find_leader_host_id(0), Some(uuid_b));
+        assert_eq!(policy.find_leader(0), Some((uuid_b, 1)));
         // Token 1 -> tablet C
-        assert_eq!(policy.find_leader_host_id(1), Some(uuid_c));
+        assert_eq!(policy.find_leader(1), Some((uuid_c, 2)));
         // Token 3000 -> tablet C (boundary)
-        assert_eq!(policy.find_leader_host_id(3000), Some(uuid_c));
+        assert_eq!(policy.find_leader(3000), Some((uuid_c, 2)));
         // Token 5000 -> wraps around to tablet A
-        assert_eq!(policy.find_leader_host_id(5000), Some(uuid_a));
+        assert_eq!(policy.find_leader(5000), Some((uuid_a, 0)));
     }
 }

--- a/src/bin/cql-stress-cassandra-stress/raft_leader_policy.rs
+++ b/src/bin/cql-stress-cassandra-stress/raft_leader_policy.rs
@@ -1,0 +1,356 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Context, Result};
+use scylla::client::session::Session;
+use scylla::cluster::{ClusterState, NodeRef};
+use scylla::policies::load_balancing::{FallbackPlan, LoadBalancingPolicy, RoutingInfo};
+use scylla::routing::Shard;
+use uuid::Uuid;
+
+/// A load balancing policy that routes requests for a specific table
+/// to the Raft leader of the corresponding tablet.
+///
+/// For all other tables/queries, it delegates to the wrapped default policy.
+///
+/// This is intended for testing ScyllaDB's strong consistency feature,
+/// where each tablet has its own Raft group and requests should be directed
+/// to the Raft leader of the tablet that owns the requested token.
+///
+/// The mapping is static and set once during initialization. It assumes
+/// that tablet topology won't change (no splits/merges/migrations) and
+/// that the Raft leader won't change during the test.
+#[derive(Debug)]
+pub struct RaftLeaderPolicy {
+    target_keyspace: String,
+    target_table: String,
+    /// Mapping from last_token -> leader host_id.
+    /// Populated after session creation via `initialize()`.
+    token_to_leader: OnceLock<BTreeMap<i64, Uuid>>,
+    /// Fallback policy for non-target-table queries or when not yet initialized.
+    default_policy: Arc<dyn LoadBalancingPolicy>,
+}
+
+impl RaftLeaderPolicy {
+    pub fn new(
+        target_keyspace: String,
+        target_table: String,
+        default_policy: Arc<dyn LoadBalancingPolicy>,
+    ) -> Self {
+        Self {
+            target_keyspace,
+            target_table,
+            token_to_leader: OnceLock::new(),
+            default_policy,
+        }
+    }
+
+    /// Initialize the policy by querying system.tablets and the ScyllaDB REST API.
+    ///
+    /// This must be called after the session is built and the schema is created.
+    /// After initialization, `pick()` will route requests for the target table
+    /// to the Raft leader of the corresponding tablet.
+    pub async fn initialize(
+        &self,
+        session: &Session,
+        api_node: &str,
+        api_port: u16,
+    ) -> Result<()> {
+        println!(
+            "Initializing RaftLeaderPolicy for {}.{}...",
+            self.target_keyspace, self.target_table
+        );
+
+        // Step 1: Get table_id from system_schema.tables
+        let table_id =
+            get_table_id(session, &self.target_keyspace, &self.target_table).await?;
+        println!("  Table ID: {}", table_id);
+
+        // Step 2: Get token -> raft_group_id mapping from system.tablets
+        let tablet_info = get_tablet_info(session, table_id).await?;
+        println!("  Found {} tablets", tablet_info.len());
+
+        // Step 3: For each unique raft_group_id, get the leader host_id via REST API
+        let http_client = reqwest::Client::new();
+        let unique_groups: std::collections::HashSet<Uuid> =
+            tablet_info.iter().map(|(_, group_id)| *group_id).collect();
+        println!(
+            "  Querying raft leaders for {} groups...",
+            unique_groups.len()
+        );
+
+        let mut group_to_leader: std::collections::HashMap<Uuid, Uuid> =
+            std::collections::HashMap::new();
+
+        for group_id in &unique_groups {
+            let leader_host_id =
+                get_raft_leader(&http_client, api_node, api_port, *group_id)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to get raft leader for group {}", group_id)
+                    })?;
+            println!("    Group {} -> Leader {}", group_id, leader_host_id);
+            group_to_leader.insert(*group_id, leader_host_id);
+        }
+
+        // Build the final token -> leader host_id mapping
+        let mut token_to_leader = BTreeMap::new();
+        for (last_token, group_id) in &tablet_info {
+            if let Some(&leader) = group_to_leader.get(group_id) {
+                token_to_leader.insert(*last_token, leader);
+            }
+        }
+
+        println!(
+            "  Raft leader mapping initialized: {} tablet entries",
+            token_to_leader.len()
+        );
+
+        self.token_to_leader
+            .set(token_to_leader)
+            .map_err(|_| anyhow::anyhow!("RaftLeaderPolicy already initialized"))?;
+
+        Ok(())
+    }
+
+    /// Find the leader host_id for a given token.
+    ///
+    /// Uses the BTreeMap to find the tablet whose range contains the token.
+    /// The tablet ranges are defined by `last_token` boundaries:
+    /// a token T belongs to the tablet with the smallest `last_token >= T`.
+    /// If T is beyond the largest `last_token`, it wraps around to the first tablet.
+    fn find_leader_host_id(&self, token_value: i64) -> Option<Uuid> {
+        let map = self.token_to_leader.get()?;
+        if map.is_empty() {
+            return None;
+        }
+        // Find the first tablet whose last_token >= the given token
+        map.range(token_value..)
+            .next()
+            .map(|(_, &uuid)| uuid)
+            // Wrap around: if token > max last_token, use the first tablet
+            .or_else(|| map.values().next().copied())
+    }
+
+    /// Check if the request targets the table we're managing.
+    fn is_target_table(&self, info: &RoutingInfo) -> bool {
+        if let Some(table) = &info.table {
+            table.ks_name() == self.target_keyspace
+                && table.table_name() == self.target_table
+        } else {
+            false
+        }
+    }
+
+    /// Find a node in the cluster by its host_id.
+    fn find_node_by_host_id<'a>(
+        host_id: Uuid,
+        cluster: &'a ClusterState,
+    ) -> Option<(NodeRef<'a>, Option<Shard>)> {
+        cluster
+            .get_nodes_info()
+            .iter()
+            .find(|node| node.host_id == host_id)
+            .map(|node| (node, None))
+    }
+}
+
+impl LoadBalancingPolicy for RaftLeaderPolicy {
+    fn pick<'a>(
+        &'a self,
+        request: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+    ) -> Option<(NodeRef<'a>, Option<Shard>)> {
+        // For the target table, try to route to the raft leader
+        if self.is_target_table(request) {
+            if let Some(token) = request.token {
+                if let Some(leader_id) = self.find_leader_host_id(token.value()) {
+                    if let Some(result) = Self::find_node_by_host_id(leader_id, cluster) {
+                        return Some(result);
+                    }
+                }
+            }
+        }
+
+        // Fallback to default policy for non-target tables or missing info
+        self.default_policy.pick(request, cluster)
+    }
+
+    fn fallback<'a>(
+        &'a self,
+        request: &'a RoutingInfo,
+        cluster: &'a ClusterState,
+    ) -> FallbackPlan<'a> {
+        self.default_policy.fallback(request, cluster)
+    }
+
+    fn name(&self) -> String {
+        format!(
+            "RaftLeaderPolicy(fallback={})",
+            self.default_policy.name()
+        )
+    }
+}
+
+/// Query system_schema.tables to get the table UUID.
+async fn get_table_id(session: &Session, keyspace: &str, table: &str) -> Result<Uuid> {
+    let result = session
+        .query_unpaged(
+            "SELECT id FROM system_schema.tables WHERE keyspace_name = ? AND table_name = ?",
+            (keyspace, table),
+        )
+        .await
+        .context("Failed to query system_schema.tables")?;
+
+    let rows = result
+        .into_rows_result()
+        .context("Expected rows result from system_schema.tables")?;
+
+    let (table_id,): (Uuid,) = rows
+        .single_row()
+        .context("Expected exactly one row for table_id lookup")?;
+
+    Ok(table_id)
+}
+
+/// Query system.tablets to get (last_token, raft_group_id) pairs for a table.
+async fn get_tablet_info(session: &Session, table_id: Uuid) -> Result<Vec<(i64, Uuid)>> {
+    // Format the UUID directly in the query since system virtual tables
+    // may not support bind markers well.
+    let query = format!(
+        "SELECT last_token, raft_group_id FROM system.tablets WHERE table_id = {}",
+        table_id
+    );
+
+    let result = session
+        .query_unpaged(query, ())
+        .await
+        .context("Failed to query system.tablets")?;
+
+    let rows = result
+        .into_rows_result()
+        .context("Expected rows result from system.tablets")?;
+
+    let mut tablet_info = Vec::new();
+    for row in rows.rows::<(i64, Uuid)>()? {
+        let (last_token, raft_group_id) =
+            row.context("Failed to deserialize tablet row")?;
+        tablet_info.push((last_token, raft_group_id));
+    }
+
+    Ok(tablet_info)
+}
+
+/// Query the ScyllaDB REST API to get the leader host for a raft group.
+async fn get_raft_leader(
+    client: &reqwest::Client,
+    node: &str,
+    port: u16,
+    group_id: Uuid,
+) -> Result<Uuid> {
+    let url = format!("http://{}:{}/raft/leader_host", node, port);
+
+    let resp = client
+        .get(&url)
+        .query(&[("group_id", group_id.to_string())])
+        .send()
+        .await
+        .with_context(|| {
+            format!("Failed to call /raft/leader_host on {}:{}", node, port)
+        })?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "/raft/leader_host returned status {}: {}",
+            resp.status(),
+            resp.text().await.unwrap_or_default()
+        );
+    }
+
+    let body = resp.text().await.context("Failed to read response body")?;
+    // Response is a JSON string - may be quoted ("uuid") or bare (uuid)
+    let trimmed = body.trim().trim_matches('"');
+    let uuid = Uuid::parse_str(trimmed).with_context(|| {
+        format!(
+            "Invalid UUID in /raft/leader_host response: {}",
+            body
+        )
+    })?;
+
+    // A zero UUID means no leader elected yet
+    if uuid.is_nil() {
+        anyhow::bail!("No leader elected yet for raft group {}", group_id);
+    }
+
+    Ok(uuid)
+}
+
+/// Extract the hostname/IP from a node address that may include a port.
+///
+/// Examples:
+/// - "127.0.0.1" -> "127.0.0.1"
+/// - "127.0.0.1:9042" -> "127.0.0.1"
+/// - "hostname" -> "hostname"
+/// - "hostname:9042" -> "hostname"
+/// - "::1" -> "::1" (IPv6, unchanged)
+pub fn extract_host(node: &str) -> &str {
+    let colon_count = node.chars().filter(|&c| c == ':').count();
+    if colon_count == 1 {
+        // "host:port" format
+        &node[..node.rfind(':').unwrap()]
+    } else {
+        // No port or IPv6 address
+        node
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_host() {
+        assert_eq!(extract_host("127.0.0.1"), "127.0.0.1");
+        assert_eq!(extract_host("127.0.0.1:9042"), "127.0.0.1");
+        assert_eq!(extract_host("hostname"), "hostname");
+        assert_eq!(extract_host("hostname:9042"), "hostname");
+        assert_eq!(extract_host("::1"), "::1");
+    }
+
+    #[test]
+    fn test_find_leader_in_btree() {
+        let default_policy =
+            scylla::policies::load_balancing::DefaultPolicy::builder().build();
+        let policy = RaftLeaderPolicy::new(
+            "ks".to_string(),
+            "tbl".to_string(),
+            default_policy,
+        );
+
+        let uuid_a = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let uuid_b = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let uuid_c = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
+
+        let mut map = BTreeMap::new();
+        map.insert(-3000, uuid_a); // tablet A: ...-3000
+        map.insert(0, uuid_b); // tablet B: -2999...0
+        map.insert(3000, uuid_c); // tablet C: 1...3000
+
+        policy.token_to_leader.set(map).unwrap();
+
+        // Token -5000 -> tablet A (first range)
+        assert_eq!(policy.find_leader_host_id(-5000), Some(uuid_a));
+        // Token -3000 -> tablet A (boundary)
+        assert_eq!(policy.find_leader_host_id(-3000), Some(uuid_a));
+        // Token -2999 -> tablet B
+        assert_eq!(policy.find_leader_host_id(-2999), Some(uuid_b));
+        // Token 0 -> tablet B (boundary)
+        assert_eq!(policy.find_leader_host_id(0), Some(uuid_b));
+        // Token 1 -> tablet C
+        assert_eq!(policy.find_leader_host_id(1), Some(uuid_c));
+        // Token 3000 -> tablet C (boundary)
+        assert_eq!(policy.find_leader_host_id(3000), Some(uuid_c));
+        // Token 5000 -> wraps around to tablet A
+        assert_eq!(policy.find_leader_host_id(5000), Some(uuid_a));
+    }
+}

--- a/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
@@ -85,7 +85,7 @@ impl SchemaOption {
 
     pub fn construct_keyspace_creation_query(&self) -> String {
         format!(
-            "CREATE KEYSPACE IF NOT EXISTS \"{keyspace}\" WITH REPLICATION = {replication};",
+            "CREATE KEYSPACE IF NOT EXISTS \"{keyspace}\" WITH REPLICATION = {replication} AND consistency = 'local';",
             keyspace = self.keyspace,
             replication = self.construct_replication_string()
         )

--- a/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
+++ b/src/bin/cql-stress-cassandra-stress/settings/option/schema.rs
@@ -85,7 +85,7 @@ impl SchemaOption {
 
     pub fn construct_keyspace_creation_query(&self) -> String {
         format!(
-            "CREATE KEYSPACE IF NOT EXISTS \"{keyspace}\" WITH REPLICATION = {replication} AND consistency = 'local';",
+            "CREATE KEYSPACE IF NOT EXISTS \"{keyspace}\" WITH REPLICATION = {replication} AND consistency = 'global';",
             keyspace = self.keyspace,
             replication = self.construct_replication_string()
         )


### PR DESCRIPTION
This is a draft PR as there are no intentions to merge it to master (and the commits aren't written in master-grain quality).
Purpose of this patch is to create a temporary custom build of cassandra-stress to do early performance testing of Scylla's strong consistency (the feature is still in experimental phase and it'll be for some time).

The main goal of this changes is to direct request to node which is running Raft leader of tablet group containing request's token.
This is achieved using custom load balancing policy in Rust driver.

With strong consistency, each tablet has its own Raft group with own Raft leader.
So, given a token of the request, the load balancing policy needs to:
- determine to which tablet the token belongs
- what is raft group of the tablet
- which host is the leader of the raft group
- direct the request to this host

Information on which shard the raft group and leader are running can be retrieved by crossing information about  tablet's replicas set (list of `(host, shard)`) and leader's host.

The load balancing policy uses a static `token -> (host, shard)` mapping.
To construct the policy, the `system.tablets` is queried for `last_token -> (raft_group_id, replicas_set)` mapping.
Then, for each raft_group_id `/raft/leader_host` REST endpoint is queried to get the host on which the Raft leader is running and target shard is extracted from `replicas_set`.

The policy is used by default so this build won't work for non-strong-consistent keyspace (it should fail during policy creation).

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1101

Note that this code was generated by AI!